### PR TITLE
feat: Add transparency and window anonymity commands

### DIFF
--- a/application/src/platform/macos/window/overlay_window.mm
+++ b/application/src/platform/macos/window/overlay_window.mm
@@ -196,6 +196,16 @@ class OverlayWindow::Impl {
         [window_ close];
     }
 
+    // TODO(@OopsOverflow): Implement this
+    auto setTransparency(int transparency) -> void { [window_ setAlphaValue:transparency / 100.0]; }
+
+    // TODO(@OopsOverflow): Implement this
+    auto toggleWindowAnonymity() -> void {
+        [window_ setCollectionBehavior:NSWindowCollectionBehaviorCanJoinAllSpaces |
+                                       NSWindowCollectionBehaviorFullScreenAuxiliary |
+                                       NSWindowCollectionBehaviorStationary];
+    }
+
     [[nodiscard]] auto getNativeHandle() const -> void* { return (__bridge void*)window_; }
 
     ~Impl() {
@@ -236,6 +246,10 @@ auto OverlayWindow::close() -> void {
     pImpl_->close();
     running_ = false;
 }
+
+auto OverlayWindow::setTransparency(int transparency) -> void { pImpl_->setTransparency(transparency); }
+
+auto OverlayWindow::toggleWindowAnonymity() -> void { pImpl_->toggleWindowAnonymity(); }
 
 [[nodiscard]] auto OverlayWindow::getNativeHandle() const -> void* { return pImpl_->getNativeHandle(); }
 

--- a/docs/technical/command_system.md
+++ b/docs/technical/command_system.md
@@ -189,6 +189,19 @@ The application comes with several built-in commands:
 - **Platform-specific**: Uses GDI+ on Windows and CoreGraphics on macOS
 - **Output**: Saves PNG files to `./screenshot` directory with timestamp-based names
 
+### Toggle Transparency Command
+- **ID**: `toggle-transparency`
+- **Purpose**: Toggles the transparency of the main application window between normal (255) and semi-transparent (100)
+- **Implementation**: `ToggleTransparencyCommand` class
+- **Platform-specific**: Uses GetLayeredWindowAttributes on Windows, platform-specific implementation for macOS
+- **Behavior**: Switches between transparency values of 100 and 255
+
+### Toggle Window Anonymity Command
+- **ID**: `toggle-window-anonymity`
+- **Purpose**: Toggles the window anonymity mode
+- **Implementation**: `ToggleWindowAnonymityCommand` class
+- **Behavior**: Switches the window between normal and anonymous modes
+
 ## Command Registration
 
 Commands are registered through the `CommandFactory` singleton:

--- a/docs/user/shortcuts.md
+++ b/docs/user/shortcuts.md
@@ -143,3 +143,5 @@ This document describes all available keyboard shortcuts in the application.
 | Toggle Window | `Ctrl+F1` | `Ctrl+F1` | Toggle main window visibility |
 | Stop Application | `Win+/` | `Cmd+/` | Stop the application |
 | Window Screenshot | `Ctrl+F2` | `Ctrl+F2` | Take a screenshot of the current window |
+| Toggle Transparency | `Ctrl+F3` | `Ctrl+F3` | Toggle window transparency |
+| Toggle Anonymity | `Ctrl+F4` | `Ctrl+F4` | Toggle window anonymity mode |

--- a/palantir-core/include/window/iwindow.hpp
+++ b/palantir-core/include/window/iwindow.hpp
@@ -77,6 +77,17 @@ public:
     virtual auto close() -> void = 0;
 
     /**
+     * @brief Set the window's transparency.
+     * @param transparency The transparency value to set (0-100).
+     */
+    virtual auto setTransparency(int transparency) -> void = 0; 
+
+    /**
+     * @brief Toggle the window's anonymity. Preventing any capture or screen sharing.
+     */
+    virtual auto toggleWindowAnonymity() -> void = 0;
+
+    /**
      * @brief Check if the window is currently running.
      * @return true if the window is running, false otherwise.
      *

--- a/palantir-core/include/window/overlay_window.hpp
+++ b/palantir-core/include/window/overlay_window.hpp
@@ -24,6 +24,8 @@ public:
     auto show() -> void override;
     auto update() -> void override;
     auto close() -> void override;
+    auto setTransparency(int transparency) -> void override;
+    auto toggleWindowAnonymity() -> void override;
     [[nodiscard]] auto getNativeHandle() const -> void* override;
 
     [[nodiscard]] auto isRunning() const -> bool override;

--- a/palantir-core/src/input/input_factory.cpp
+++ b/palantir-core/src/input/input_factory.cpp
@@ -44,6 +44,8 @@ auto InputFactory::createDefaultConfig(const std::string& configPath) -> void {
                << "toggle = Ctrl+F1    ; Toggle window visibility\n"
                << "stop = Win+/        ; Stop application\n"
                << "window-screenshot = Ctrl+F2    ; Take screenshot of current window\n"
+               << "toggle-transparency = Ctrl+F3    ; Toggle window transparency\n"
+               << "toggle-window-anonymity = Ctrl+F4    ; Toggle window anonymity\n"
 #else
                << "toggle = Ctrl+F1    ; Toggle window visibility\n"
                << "stop = Cmd+/        ; Stop application\n"

--- a/plugins/commands/CMakeLists.txt
+++ b/plugins/commands/CMakeLists.txt
@@ -6,6 +6,8 @@ set(COMMANDS_PLUGIN_SOURCES
     ${PROJECT_ROOT}/plugins/commands/src/command/show_command.cpp
     ${PROJECT_ROOT}/plugins/commands/src/command/stop_command.cpp
     ${PROJECT_ROOT}/plugins/commands/src/command/window_screenshot_command.cpp
+    ${PROJECT_ROOT}/plugins/commands/src/command/toggle_transparency_command.cpp
+    ${PROJECT_ROOT}/plugins/commands/src/command/toggle_window_anonymity_command.cpp
 )
 
 set(COMMANDS_PLUGIN_HEADERS
@@ -13,6 +15,8 @@ set(COMMANDS_PLUGIN_HEADERS
     ${PROJECT_ROOT}/plugins/commands/include/command/show_command.hpp
     ${PROJECT_ROOT}/plugins/commands/include/command/stop_command.hpp
     ${PROJECT_ROOT}/plugins/commands/include/command/window_screenshot_command.hpp
+    ${PROJECT_ROOT}/plugins/commands/include/command/toggle_transparency_command.hpp
+    ${PROJECT_ROOT}/plugins/commands/include/command/toggle_window_anonymity_command.hpp
     ${PROJECT_ROOT}/plugins/commands/include/plugin_export.hpp
 )
 
@@ -20,11 +24,13 @@ if(WIN32)
     set(COMMANDS_PLUGIN_SOURCES
         ${COMMANDS_PLUGIN_SOURCES}
         ${PROJECT_ROOT}/plugins/commands/src/platform/windows/command/window_screenshot_command.cpp
+        ${PROJECT_ROOT}/plugins/commands/src/platform/windows/command/toggle_transparency_command.cpp
     )
 elseif(APPLE)
     set(COMMANDS_PLUGIN_SOURCES
         ${COMMANDS_PLUGIN_SOURCES}
         ${PROJECT_ROOT}/plugins/commands/src/platform/macos/command/window_screenshot_command.cpp
+        ${PROJECT_ROOT}/plugins/commands/src/platform/macos/command/toggle_transparency_command.cpp
     )
 endif()
 

--- a/plugins/commands/include/command/toggle_transparency_command.hpp
+++ b/plugins/commands/include/command/toggle_transparency_command.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <memory>
+#include "command/icommand.hpp"
+#include "Application.hpp"
+#include "plugin_export.hpp"
+
+namespace interview_cheater::command {
+
+class COMMANDS_PLUGIN_API ToggleTransparencyCommand : public ICommand {
+public:
+    ToggleTransparencyCommand();
+    ~ToggleTransparencyCommand() override = default;
+    
+    // Rule of 5
+    ToggleTransparencyCommand(const ToggleTransparencyCommand&) = delete;
+    auto operator=(const ToggleTransparencyCommand&) -> ToggleTransparencyCommand& = delete;
+    ToggleTransparencyCommand(ToggleTransparencyCommand&&) = delete;
+    auto operator=(ToggleTransparencyCommand&&) -> ToggleTransparencyCommand& = delete;
+    auto execute() -> void override;
+    auto useDebounce() -> bool override;
+
+private:
+#pragma warning(push)
+#pragma warning(disable: 4251)
+    std::shared_ptr<Application> app_;
+#pragma warning(pop)
+
+    auto getTransparency() -> int;
+};
+
+} // namespace interview_cheater::command 

--- a/plugins/commands/include/command/toggle_window_anonymity_command.hpp
+++ b/plugins/commands/include/command/toggle_window_anonymity_command.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <memory>
+#include "command/icommand.hpp"
+#include "Application.hpp"
+#include "plugin_export.hpp"
+
+namespace interview_cheater::command {
+
+class COMMANDS_PLUGIN_API ToggleWindowAnonymityCommand : public ICommand {
+public:
+    ToggleWindowAnonymityCommand();
+    ~ToggleWindowAnonymityCommand() override = default;
+    
+    // Rule of 5
+    ToggleWindowAnonymityCommand(const ToggleWindowAnonymityCommand&) = delete;
+    auto operator=(const ToggleWindowAnonymityCommand&) -> ToggleWindowAnonymityCommand& = delete;
+    ToggleWindowAnonymityCommand(ToggleWindowAnonymityCommand&&) = delete;
+    auto operator=(ToggleWindowAnonymityCommand&&) -> ToggleWindowAnonymityCommand& = delete;
+    auto execute() -> void override;
+    auto useDebounce() -> bool override;
+
+private:
+#pragma warning(push)
+#pragma warning(disable: 4251)
+    std::shared_ptr<Application> app_;
+#pragma warning(pop)
+};
+
+} // namespace interview_cheater::command 

--- a/plugins/commands/src/command/commands_plugin.cpp
+++ b/plugins/commands/src/command/commands_plugin.cpp
@@ -3,6 +3,8 @@
 #include "command/show_command.hpp"
 #include "command/stop_command.hpp"
 #include "command/window_screenshot_command.hpp"
+#include "command/toggle_transparency_command.hpp"
+#include "command/toggle_window_anonymity_command.hpp"
 
 namespace interview_cheater::plugins {
 
@@ -24,11 +26,21 @@ static auto createWindowScreenshotCommand() -> std::unique_ptr<command::ICommand
     return std::make_unique<command::WindowScreenshotCommand>();
 }
 
+static auto createToggleTransparencyCommand() -> std::unique_ptr<command::ICommand> {
+    return std::make_unique<command::ToggleTransparencyCommand>();
+}
+
+static auto createToggleWindowAnonymityCommand() -> std::unique_ptr<command::ICommand> {
+    return std::make_unique<command::ToggleWindowAnonymityCommand>();
+}
+
 auto CommandsPlugin::initialize() -> bool {
     // Register commands using function pointers
     command::CommandFactory::getInstance().registerCommand("toggle", &createShowCommand);
     command::CommandFactory::getInstance().registerCommand("stop", &createStopCommand);
     command::CommandFactory::getInstance().registerCommand("window-screenshot", &createWindowScreenshotCommand);
+    command::CommandFactory::getInstance().registerCommand("toggle-transparency", &createToggleTransparencyCommand);
+    command::CommandFactory::getInstance().registerCommand("toggle-window-anonymity", &createToggleWindowAnonymityCommand);
     return true;
 }
 
@@ -37,6 +49,8 @@ auto CommandsPlugin::shutdown() -> void {
     command::CommandFactory::getInstance().unregisterCommand("toggle");
     command::CommandFactory::getInstance().unregisterCommand("stop");
     command::CommandFactory::getInstance().unregisterCommand("window-screenshot");
+    command::CommandFactory::getInstance().unregisterCommand("toggle-transparency");
+    command::CommandFactory::getInstance().unregisterCommand("toggle-window-anonymity");
 }
 
 auto CommandsPlugin::getName() const -> std::string {

--- a/plugins/commands/src/command/toggle_transparency_command.cpp
+++ b/plugins/commands/src/command/toggle_transparency_command.cpp
@@ -1,0 +1,25 @@
+#include "command/toggle_transparency_command.hpp"
+#include "window/window_manager.hpp"
+#include "window/iwindow.hpp"
+
+namespace interview_cheater::command {
+
+ToggleTransparencyCommand::ToggleTransparencyCommand() : app_(Application::getInstance()) {}  // NOLINT
+
+auto ToggleTransparencyCommand::execute() -> void {
+    auto windowManager = app_->getWindowManager();
+    if (auto window = windowManager->getFirstWindow()) {
+        int transparency = getTransparency();
+        if (transparency == 100) {
+            window->setTransparency(255);
+        } else {
+            window->setTransparency(100);
+        }
+    } else {
+        throw std::runtime_error("No window found");
+    }
+}
+
+auto ToggleTransparencyCommand::useDebounce() -> bool { return true; }
+
+} // namespace interview_cheater::command 

--- a/plugins/commands/src/command/toggle_window_anonymity_command.cpp
+++ b/plugins/commands/src/command/toggle_window_anonymity_command.cpp
@@ -1,0 +1,20 @@
+#include "command/toggle_window_anonymity_command.hpp"
+#include "window/window_manager.hpp"
+#include "window/iwindow.hpp"
+
+namespace interview_cheater::command {
+
+ToggleWindowAnonymityCommand::ToggleWindowAnonymityCommand() : app_(Application::getInstance()) {}  // NOLINT
+
+auto ToggleWindowAnonymityCommand::execute() -> void {
+    auto windowManager = app_->getWindowManager();
+    if (auto window = windowManager->getFirstWindow()) {
+        window->toggleWindowAnonymity();
+    } else {
+        throw std::runtime_error("No window found");
+    }
+}
+
+auto ToggleWindowAnonymityCommand::useDebounce() -> bool { return true; }
+
+} // namespace interview_cheater::command 

--- a/plugins/commands/src/platform/macos/command/toggle_transparency_command.cpp
+++ b/plugins/commands/src/platform/macos/command/toggle_transparency_command.cpp
@@ -1,0 +1,12 @@
+#include "command/toggle_transparency_command.hpp"
+
+#include "window/window_manager.hpp"
+#include "window/iwindow.hpp"
+
+namespace interview_cheater::command {
+
+auto ToggleTransparencyCommand::getTransparency() -> int {
+    // TODO(@OopsOverflow): Implement this
+    return 0;
+}
+} // namespace interview_cheater::command 

--- a/plugins/commands/src/platform/windows/command/toggle_transparency_command.cpp
+++ b/plugins/commands/src/platform/windows/command/toggle_transparency_command.cpp
@@ -1,0 +1,23 @@
+#include "command/toggle_transparency_command.hpp"
+
+#include <windows.h>
+
+#include "window/window_manager.hpp"
+#include "window/iwindow.hpp"
+
+namespace interview_cheater::command {
+
+auto ToggleTransparencyCommand::getTransparency() -> int {
+    auto windowManager = app_->getWindowManager();
+    if (auto window = windowManager->getFirstWindow()) {
+        auto hwnd = reinterpret_cast<HWND>(window->getNativeHandle());
+        if (hwnd != nullptr) {
+            BYTE transparency;
+            if (GetLayeredWindowAttributes(hwnd, 0, &transparency, nullptr) == TRUE) {
+                return transparency;
+            }
+        }
+    }
+    return 0;
+}
+} // namespace interview_cheater::command 

--- a/plugins/commands/tests/CMakeLists.txt
+++ b/plugins/commands/tests/CMakeLists.txt
@@ -12,6 +12,8 @@ add_executable(${TEST_TARGET_NAME}
     command/window_screenshot_command_test.cpp
     command/windows_screenshot_command_test.cpp
     command/macos_screenshot_command_test.cpp
+    command/toggle_transparency_command_test.cpp
+    command/toggle_window_anonymity_command_test.cpp
 )
 
 setup_target_testing(${TEST_TARGET_NAME})

--- a/plugins/commands/tests/command/toggle_transparency_command_test.cpp
+++ b/plugins/commands/tests/command/toggle_transparency_command_test.cpp
@@ -1,0 +1,78 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "command/toggle_transparency_command.hpp"
+#include "../mocks/mock_application.hpp"
+#include "../mocks/mock_window_manager.hpp"
+#include "../mocks/mock_window.hpp"
+
+using namespace interview_cheater;
+using namespace interview_cheater::command;
+using namespace interview_cheater::test;
+using namespace testing;
+
+class ToggleTransparencyCommandTest : public Test {
+protected:
+    void SetUp() override {
+        mockWindow = std::make_shared<MockWindow>();
+        mockWindowManager = std::make_shared<MockWindowManager>();
+        mockApp = std::make_shared<MockApplication>("");
+
+        // Set up default behaviors
+        EXPECT_CALL(*mockApp, getWindowManager())
+            .WillRepeatedly(Return(mockWindowManager));
+        
+        interview_cheater::Application::setInstance(mockApp);
+        interview_cheater::window::WindowManager::setInstance(mockWindowManager);
+    }
+
+    void TearDown() override {
+        interview_cheater::Application::setInstance(nullptr);
+        interview_cheater::window::WindowManager::setInstance(nullptr);
+        mockApp.reset();
+        mockWindow.reset();
+        mockWindowManager.reset();
+    }
+
+    std::shared_ptr<MockWindow> mockWindow;
+    std::shared_ptr<MockWindowManager> mockWindowManager;
+    std::shared_ptr<MockApplication> mockApp;
+};
+
+TEST_F(ToggleTransparencyCommandTest, ExecuteTogglesTransparencyWhenWindowExists) {
+    // Arrange
+    EXPECT_CALL(*mockWindowManager, getFirstWindow())
+        .Times(2)
+        .WillRepeatedly(Return(mockWindow));
+
+    EXPECT_CALL(*mockWindow, getNativeHandle())
+        .Times(1)
+        .WillOnce(Return(nullptr)); // TODO(@Djoe-Denne) create a mockable wrapper for window update function
+
+    EXPECT_CALL(*mockWindow, setTransparency(100))
+        .Times(1);
+
+    ToggleTransparencyCommand command;
+
+    // Act
+    command.execute();
+}
+
+TEST_F(ToggleTransparencyCommandTest, ExecuteThrowsWhenNoWindow) {
+    // Arrange
+    EXPECT_CALL(*mockWindowManager, getFirstWindow())
+        .WillOnce(Return(nullptr));
+
+    ToggleTransparencyCommand command;
+
+    // Act & Assert
+    EXPECT_THROW(command.execute(), std::runtime_error);
+}
+
+TEST_F(ToggleTransparencyCommandTest, UseDebounceReturnsTrue) {
+    // Arrange
+    ToggleTransparencyCommand command;
+
+    // Act & Assert
+    EXPECT_TRUE(command.useDebounce());
+} 

--- a/plugins/commands/tests/command/toggle_window_anonymity_command_test.cpp
+++ b/plugins/commands/tests/command/toggle_window_anonymity_command_test.cpp
@@ -1,0 +1,73 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "command/toggle_window_anonymity_command.hpp"
+#include "../mocks/mock_application.hpp"
+#include "../mocks/mock_window_manager.hpp"
+#include "../mocks/mock_window.hpp"
+
+using namespace interview_cheater;
+using namespace interview_cheater::command;
+using namespace interview_cheater::test;
+using namespace testing;
+
+class ToggleWindowAnonymityCommandTest : public Test {
+protected:
+    void SetUp() override {
+        mockWindow = std::make_shared<MockWindow>();
+        mockWindowManager = std::make_shared<MockWindowManager>();
+        mockApp = std::make_shared<MockApplication>("");
+
+        // Set up default behaviors
+        EXPECT_CALL(*mockApp, getWindowManager())
+            .WillRepeatedly(Return(mockWindowManager));
+            
+        interview_cheater::Application::setInstance(mockApp);
+        interview_cheater::window::WindowManager::setInstance(mockWindowManager);
+    }
+
+    void TearDown() override {
+        interview_cheater::Application::setInstance(nullptr);
+        interview_cheater::window::WindowManager::setInstance(nullptr);
+        mockApp.reset();
+        mockWindow.reset();
+        mockWindowManager.reset();
+    }
+    
+    std::shared_ptr<MockWindow> mockWindow;
+    std::shared_ptr<MockWindowManager> mockWindowManager;
+    std::shared_ptr<MockApplication> mockApp;
+};
+
+TEST_F(ToggleWindowAnonymityCommandTest, ExecuteTogglesAnonymityWhenWindowExists) {
+    // Arrange
+    EXPECT_CALL(*mockWindowManager, getFirstWindow())
+        .WillOnce(Return(mockWindow));
+    
+    EXPECT_CALL(*mockWindow, toggleWindowAnonymity())
+        .Times(1);
+
+    ToggleWindowAnonymityCommand command;
+
+    // Act
+    command.execute();
+}
+
+TEST_F(ToggleWindowAnonymityCommandTest, ExecuteThrowsWhenNoWindow) {
+    // Arrange
+    EXPECT_CALL(*mockWindowManager, getFirstWindow())
+        .WillOnce(Return(nullptr));
+
+    ToggleWindowAnonymityCommand command;
+
+    // Act & Assert
+    EXPECT_THROW(command.execute(), std::runtime_error);
+}
+
+TEST_F(ToggleWindowAnonymityCommandTest, UseDebounceReturnsTrue) {
+    // Arrange
+    ToggleWindowAnonymityCommand command;
+
+    // Act & Assert
+    EXPECT_TRUE(command.useDebounce());
+} 

--- a/plugins/commands/tests/mocks/mock_window.hpp
+++ b/plugins/commands/tests/mocks/mock_window.hpp
@@ -12,6 +12,8 @@ public:
     MOCK_METHOD(void, show, (), (override));
     MOCK_METHOD(void, update, (), (override));
     MOCK_METHOD(void, close, (), (override));
+    MOCK_METHOD(void, setTransparency, (int), (override));
+    MOCK_METHOD(void, toggleWindowAnonymity, (), (override));
     MOCK_METHOD(bool, isRunning, (), (const, override));
     MOCK_METHOD(void, setRunning, (bool), (override));
     MOCK_METHOD(void*, getNativeHandle, (), (const, override));


### PR DESCRIPTION
Implement new commands for window transparency and anonymity control:
- Add ToggleTransparencyCommand to switch window transparency levels
- Create ToggleWindowAnonymityCommand to toggle window capture prevention
- Update IWindow interface with new methods for transparency and anonymity
- Implement platform-specific transparency and anonymity handling for Windows and macOS
- Add corresponding keyboard shortcuts (Ctrl+F3 and Ctrl+F4)
- Extend command system documentation with new command descriptions
- Create comprehensive unit tests for new commands
- Update mock window interface to support new methods