### PR TITLE
ci: Add GitHub Actions workflows for cache cleanup

### DIFF
--- a/.github/workflows/clear-caches-master.yml
+++ b/.github/workflows/clear-caches-master.yml
@@ -1,0 +1,28 @@
+name: cleanup caches by a branch (closed PR)
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    if: (github.event_name == 'pull_request')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cleanup
+        run: |
+          echo "Fetching list of cache key"
+          cacheKeysForPR=$(gh cache list --ref $BRANCH --json id --jq '.[].id')
+
+          ## Setting this to not fail the workflow while deleting cache keys.
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh cache delete $cacheKey
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          BRANCH: ${{ github.ref }}

--- a/.github/workflows/clear-caches-pr.yml
+++ b/.github/workflows/clear-caches-pr.yml
@@ -1,28 +1,13 @@
 name: cleanup caches by a branch
 on:
-  pull_request:
-    types:
-      - closed
   issue_comment:
     types: [created]
 
 jobs:
   cleanup:
-    if: (github.event_name == 'pull_request') || (github.event_name == 'issue_comment' && github.event.comment.body == 'clear caches')
+    if: (github.event_name == 'issue_comment' && github.event.comment.body == 'clear caches')
     runs-on: ubuntu-latest
     steps:
-      - name: Get PR data
-        id: pr
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const { data: pr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number
-            });
-            core.setOutput('sha', pr.head.sha);
-
       - name: Cleanup
         run: |
           echo "Fetching list of cache key"
@@ -39,4 +24,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-          BRANCH: ${{ steps.pr.outputs.sha }}
+          BRANCH: refs/pull/${{ github.event.issue.number }}/merge


### PR DESCRIPTION
- Create two new workflows to manage GitHub Actions caches
- `clear-caches-master.yml`: Automatically clear caches after PR closure
- `clear-caches-pr.yml`: Allow manual cache clearing via issue comment
- Use GitHub CLI to list and delete branch-specific caches