### PR TITLE
ci: Add debug logging for build artifacts in GitHub Actions workflow

### DIFF
--- a/.github/workflows/actions/build/action.yml
+++ b/.github/workflows/actions/build/action.yml
@@ -38,6 +38,7 @@ runs:
       shell: pwsh
       run: |
         cmake --build ${{ inputs.build-dir }} --config Release --verbose
+        Get-ChildItem -Path ${{ inputs.build-dir }}/bin -Recurse
         Get-ChildItem -Path ${{ inputs.build-dir }}/bin -Recurse | ForEach-Object {
           if (-not $_.PSIsContainer) {
             try {


### PR DESCRIPTION
- Recursively list files in build directory's bin folder
- Enhance diagnostic information for build artifact discovery
- Use PowerShell `Get-ChildItem` to search for build output files