### PR TITLE
Update GitHub Actions workflows to improve Windows compatibility and …

### DIFF
--- a/.github/workflows/actions/quality/action.yml
+++ b/.github/workflows/actions/quality/action.yml
@@ -2,12 +2,6 @@ name: 'Setup CMake'
 description: 'Sets up CMake build environment and caching'
 
 inputs:
-  github-token:
-    description: 'GitHub token for authentication'
-    required: true
-  cache-key:
-    description: 'Prefix for cache keys'
-    required: true
   build-dir:
     description: 'CMake build directory'
     required: true
@@ -19,21 +13,24 @@ runs:
   using: composite
   steps:  
     - name: Configure CMake
-      shell: bash
+      shell: pwsh
       run: |
-        cmake -B ${{ inputs.build-dir }} -DCMAKE_BUILD_TYPE=Release -DGITHUB_TOKEN=${{ inputs.github-token }} -DQUALITY_ONLY=ON
+        if (-not (Test-Path -Path ${{ inputs.build-dir }})) {
+            New-Item -ItemType Directory -Path ${{ inputs.build-dir }} -Force
+        }
+        cmake -B ${{ inputs.build-dir }} -DCMAKE_BUILD_TYPE=Release -DQUALITY_ONLY=ON
 
     - name: Check Format
-      shell: bash
+      shell: pwsh
       run: cmake --build ${{ inputs.build-dir }} --target format-check
     
     - name: Run Lint Check
-      shell: bash
+      shell: pwsh
       continue-on-error: true
       run: cmake --build ${{ inputs.build-dir }} --target lint-check
 
     - name: Analyze Lint Results
-      shell: bash
+      shell: pwsh
       run: |
         cat ${{ inputs.build-dir }}/lint-reports/report.txt
         cmake --build ${{ inputs.build-dir }} --target lint-analyze

--- a/.github/workflows/code-quality-master.yml
+++ b/.github/workflows/code-quality-master.yml
@@ -20,8 +20,7 @@ concurrency:
 env:
   FORCE_COLOR: 1  # Enable colored output in logs
   TERM: xterm-256color  # Terminal type for better formatting
-  CMAKE_BUILD_DIR: ${{ github.workspace }}/build
-  CACHE_KEY_PREFIX: v1  # Increment this to invalidate all caches
+  CMAKE_BUILD_DIR: ${{ github.workspace }}\build
 
 jobs:
   code-quality:
@@ -30,6 +29,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/workflows/actions/quality
         with:
-          github-token: ${{ secrets.PALANTIR_GHA }}
-          cache-key: ${{ env.CACHE_KEY_PREFIX }}
           build-dir: ${{ env.CMAKE_BUILD_DIR }}

--- a/.github/workflows/code-quality-pr.yml
+++ b/.github/workflows/code-quality-pr.yml
@@ -17,8 +17,7 @@ permissions:
 env:
   FORCE_COLOR: 1  # Enable colored output in logs
   TERM: xterm-256color  # Terminal type for better formatting
-  CMAKE_BUILD_DIR: ${{ github.workspace }}/build
-  CACHE_KEY_PREFIX: v1  # Increment this to invalidate all caches
+  CMAKE_BUILD_DIR: ${{ github.workspace }}\build
 
 jobs:
   code-quality:
@@ -61,8 +60,6 @@ jobs:
       - uses: ./.github/workflows/actions/quality
         id: quality
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          cache-key: ${{ env.CACHE_KEY_PREFIX }}
           build-dir: ${{ env.CMAKE_BUILD_DIR }}
 
       - name: Read lint report
@@ -70,7 +67,7 @@ jobs:
         shell: bash
         continue-on-error: true
         run: |
-          REPORT_CONTENT=$(cat ${{ env.CMAKE_BUILD_DIR }}/lint-reports/github-report.txt)
+          REPORT_CONTENT=$(cat ${{ env.CMAKE_BUILD_DIR }}\lint-reports\github-report.txt)
           echo "report<<EOF" >> $GITHUB_OUTPUT
           echo "$REPORT_CONTENT" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT


### PR DESCRIPTION
…simplify configurations

- Change CMAKE_BUILD_DIR path separator to backslash for Windows compatibility
- Remove unnecessary cache key inputs from quality action
- Update lint report file path to use backslashes for consistency in Windows environments
- Refactor action inputs to streamline CMake setup process